### PR TITLE
using classify to capitalize the controller names generated by generator [fixes issue #67]

### DIFF
--- a/lib/stealth/generators/generate/flow/controllers/controller.tt
+++ b/lib/stealth/generators/generate/flow/controllers/controller.tt
@@ -1,4 +1,4 @@
-class <%= name.capitalize.camelize.underscore.pluralize %>Controller < BotController
+class <%= name.classify.pluralize %>Controller < BotController
 
   def ask_example
     send_replies


### PR DESCRIPTION
Fix for [Issue #67](https://github.com/hellostealth/stealth/issues/67)