### PR TITLE
Namespace Stealth Sidekiq queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Stealth v1.1.0
 
+## Breaking Changes
+
+* [Sidekiq] Sidekiq queues have been renamed from `webhooks` and `default` to `stealth_webhooks` and `stealth_replies`. Please ensure your `Procfile` is adjusted accordingly.
+
 ## Enhancements
 
 * [Controllers] `current_session_id` now references the session ID in controllers

--- a/lib/stealth/generators/builder/Procfile.dev
+++ b/lib/stealth/generators/builder/Procfile.dev
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-sidekiq: bundle exec sidekiq -C config/sidekiq.yml -q webhooks -q default -r ./config/boot.rb
+sidekiq: bundle exec sidekiq -C config/sidekiq.yml -q stealth_webhooks -q stealth_replies -r ./config/boot.rb

--- a/lib/stealth/scheduled_reply.rb
+++ b/lib/stealth/scheduled_reply.rb
@@ -4,7 +4,7 @@
 module Stealth
 
   class ScheduledReplyJob < Stealth::Jobs
-    sidekiq_options queue: :webhooks, retry: false
+    sidekiq_options queue: :stealth_replies, retry: false
 
     def perform(service, user_id, flow, state)
       service_message = ServiceMessage.new(service: service)

--- a/lib/stealth/services/jobs/handle_message_job.rb
+++ b/lib/stealth/services/jobs/handle_message_job.rb
@@ -5,7 +5,7 @@ module Stealth
   module Services
 
     class HandleMessageJob < Stealth::Jobs
-      sidekiq_options queue: :webhooks, retry: false
+      sidekiq_options queue: :stealth_webhooks, retry: false
 
       def perform(service, params, headers)
         dispatcher = Stealth::Dispatcher.new(


### PR DESCRIPTION
This allows Stealth to share a Redis database with other Sidekiq processes.