### PR TITLE
Implement redirects_to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Breaking Changes
 
 * [Sidekiq] Sidekiq queues have been renamed from `webhooks` and `default` to `stealth_webhooks` and `stealth_replies`. Please ensure your `Procfile` is adjusted accordingly.
+* [Flows] `flow_map.current_state.fails_to` now returns a `Stealth::Session` instead of a `Stealth::Flow::State`. This might affect your `catch_alls`.
 
 ## Enhancements
 
@@ -10,6 +11,8 @@
 * [Replies] Added support for dynamic delays
 * [Replies] Added support for service-specific variants
 * [Models] ActiveRecord is now part of the generated bot Gemfile and can be removed from bots
+* [Flows] Added support for `redirects_to` during state declaration. If specified, will automatically step a user to the specified state or session.
+* [Flows] `redirects_to` and `fails_to` now support a session string as an argument (`my_flow->some_state`). This allows you to fail and redirect to other flows. A state name specified as a string or symbol is still allowed.
 * [Errors] Backtraces are now more readable in logs
 
 ## Bug Fixes

--- a/docs/03-basics.md
+++ b/docs/03-basics.md
@@ -117,13 +117,13 @@ The `fails_to` option allows you to specify a state that a user should be redire
 
 A freshly generated bot will contain sample `CatchAll` code for redirecting a user to a `fails_to` state.
 
-The `fails_to` option takes a state name (string or symbol) or a session key. See [Redis Backed Sessions](#sessions.redis_backed_sessions) for more info about session keys. By specifying a session key, you can fail to a completely different flow from the one where the error occurred.
+The `fails_to` option takes a state name (string or symbol) or a session key. See [Redis Backed Sessions](#sessions.redis_backed_sessions) (or in the FlowMap example above) for more info about session keys. By specifying a session key, you can fail to a completely different flow from the one where the error occurred.
 
 ## redirects_to
 
 The `redirects_to` option allows you specify a state that a user should be redirected to. This is useful if you have deprecated a state where existing users may still have open sessions pointing to the state. When a user returns to your bot, they will be redirected to the flow and state specified by this option.
 
-Like `fails_to` above, the `redirects_to` option takes a state name (string or symbol) or a session key. See [Redis Backed Sessions](#sessions.redis_backed_sessions) for more info about session keys. By specifying a session key, you can fail to a completely different flow from the one where the error occurred.
+Like `fails_to` above, the `redirects_to` option takes a state name (string or symbol) or a session key. See [Redis Backed Sessions](#sessions.redis_backed_sessions) (or in the FlowMap example above) for more info about session keys. By specifying a session key, you can fail to a completely different flow from the one where the error occurred.
 
 ## Say, Ask, Get
 

--- a/docs/03-basics.md
+++ b/docs/03-basics.md
@@ -75,6 +75,8 @@ class FlowMap
     state :say_hello
     state :ask_name
     state :get_name, fails_to: :ask_name
+    state :say_wow, redirects_to: :say_hello
+    state :say_bye, redirects_to: 'goodbye->say_goodbye'
   end
 
   flow :goodbye do
@@ -89,9 +91,9 @@ class FlowMap
 end
 ```
 
-Here we have defined three flows: `hello`, `goodbye`, and `catch_all`. For the most part, these are default flows that are generated automatically when you create a new bot but we have made a few changes to highlight some functionality.
+Here we have defined three flows: `hello`, `goodbye`, and `catch_all`. These are the default flows that are generated for you when you create a new bot. We have made a few changes above to highlight some functionality.
 
-In the `hello` flow, the second state asks a user for their name. In the third state of `hello`, you see another option: `fails_to`. This is used to tell Stealth to return the user to the specified state if the `get_name` state raises an error or fails in another way. There are more details in the `CatchAll` section below.
+Each flow consists of an arbitrary number of states. These states should each have a corresponding controller action by the same name. States also support two additional options: `fails_to` and `redirects_to` which we explain below.
 
 ## Default Flows
 
@@ -108,6 +110,20 @@ Stealth also comes packaged with a `catch_all` flow. Stealth CatchAlls are desig
 Error handling is one of the most important parts of building great bots. We recommend that bot designers and developers spend sufficient time building the CatchAll states.
 
 See the Catch All (#catchalls) section for more information on how Stealth handles `catch_all` flows.
+
+## fails_to
+
+The `fails_to` option allows you to specify a state that a user should be redirected to in case of an error. The `CatchAllsController` will still be responsible for determining how to handle the error, but by specifying a `fails_to` state here, the `CatchAllsController` is able to redirect accordingly.
+
+A freshly generated bot will contain sample `CatchAll` code for redirecting a user to a `fails_to` state.
+
+The `fails_to` option takes a state name (string or symbol) or a session key. See [Redis Backed Sessions](#sessions.redis_backed_sessions) for more info about session keys. By specifying a session key, you can fail to a completely different flow from the one where the error occurred.
+
+## redirects_to
+
+The `redirects_to` option allows you specify a state that a user should be redirected to. This is useful if you have deprecated a state where existing users may still have open sessions pointing to the state. When a user returns to your bot, they will be redirected to the flow and state specified by this option.
+
+Like `fails_to` above, the `redirects_to` option takes a state name (string or symbol) or a session key. See [Redis Backed Sessions](#sessions.redis_backed_sessions) for more info about session keys. By specifying a session key, you can fail to a completely different flow from the one where the error occurred.
 
 ## Say, Ask, Get
 

--- a/lib/stealth/controller/controller.rb
+++ b/lib/stealth/controller/controller.rb
@@ -60,6 +60,12 @@ module Stealth
       @action_name = action
       @action_name ||= current_session.state_string
 
+      # Check if the user needs to be redirected
+      if current_session.flow.current_state.redirects_to.present?
+        step_to(session: current_session.flow.current_state.redirects_to)
+        return
+      end
+
       run_callbacks :action do
         begin
           flow_controller.send(@action_name)

--- a/lib/stealth/flow/base.rb
+++ b/lib/stealth/flow/base.rb
@@ -12,7 +12,7 @@ module Stealth
 
     class_methods do
       def flow(flow_name, &specification)
-        flow_spec[flow_name.to_sym] = Specification.new(&specification)
+        flow_spec[flow_name.to_sym] = Specification.new(flow_name, &specification)
       end
     end
 

--- a/lib/stealth/flow/specification.rb
+++ b/lib/stealth/flow/specification.rb
@@ -4,10 +4,12 @@
 module Stealth
   module Flow
     class Specification
+      attr_reader :flow_name
       attr_accessor :states, :initial_state
 
-      def initialize(&specification)
+      def initialize(flow_name, &specification)
         @states = Hash.new
+        @flow_name = flow_name
         instance_eval(&specification)
       end
 

--- a/lib/stealth/flow/state.rb
+++ b/lib/stealth/flow/state.rb
@@ -8,14 +8,19 @@ module Stealth
       include Comparable
 
       attr_accessor :name
-      attr_reader :spec, :fails_to
+      attr_reader :spec, :fails_to, :redirects_to
 
-      def initialize(name, spec, fails_to = nil)
-        if fails_to.present? && !fails_to.is_a?(Stealth::Flow::State)
-          raise(ArgumentError, 'fails_to state should be a Stealth::Flow::State')
+      def initialize(name:, spec:, fails_to: nil, redirects_to: nil)
+        if fails_to.present? && !fails_to.is_a?(Stealth::Session)
+          raise(ArgumentError, 'fails_to state should be a Stealth::Session')
         end
 
-        @name, @spec, @fails_to = name, spec, fails_to
+        if redirects_to.present? && !redirects_to.is_a?(Stealth::Session)
+          raise(ArgumentError, 'redirects_to state should be a Stealth::Session')
+        end
+
+        @name, @spec = name, spec
+        @fails_to, @redirects_to = fails_to, redirects_to
       end
 
       def <=>(other_state)

--- a/lib/stealth/generators/builder/bot/controllers/catch_alls_controller.rb
+++ b/lib/stealth/generators/builder/bot/controllers/catch_alls_controller.rb
@@ -3,19 +3,16 @@ class CatchAllsController < BotController
   def level1
     send_replies
 
-    if previous_session_specifies_fails_to?
-      step_to flow: previous_session.flow_string, state: previous_state.to_s
+    if fail_session.present?
+      step_to session: fails_to_session
     else
       step_to session: previous_session - 2.states
     end
   end
 
 private
-   def previous_session_specifies_fails_to?
-     previous_state.present?
-   end
 
-   def previous_state
+   def fail_session
      previous_session.flow.current_state.fails_to
    end
 

--- a/lib/stealth/session.rb
+++ b/lib/stealth/session.rb
@@ -98,6 +98,10 @@ module Stealth
     end
 
     private
+    def self.is_a_session_string?(string)
+      session_regex = /(.+)(#{SLUG_SEPARATOR})(.+)/
+      !!string.match(session_regex)
+    end
 
       def canonical_session_slug(flow:, state:)
         [flow, state].join(SLUG_SEPARATOR)

--- a/lib/stealth/session.rb
+++ b/lib/stealth/session.rb
@@ -9,15 +9,18 @@ module Stealth
     attr_reader :flow, :state, :user_id, :previous
     attr_accessor :session
 
-    def initialize(user_id:, previous: false)
+    def initialize(user_id: nil, previous: false)
       @user_id = user_id
       @previous = previous
 
-      unless defined?($redis) && $redis.present?
-        raise(Stealth::Errors::RedisNotConfigured, "Please make sure REDIS_URL is configured before using sessions")
+      if user_id.present?
+        unless defined?($redis) && $redis.present?
+          raise(Stealth::Errors::RedisNotConfigured, "Please make sure REDIS_URL is configured before using sessions")
+        end
+
+        get
       end
 
-      get
       self
     end
 

--- a/lib/stealth/session.rb
+++ b/lib/stealth/session.rb
@@ -61,7 +61,7 @@ module Stealth
       store_current_to_previous(flow: flow, state: state)
 
       @flow = nil
-      @session = canonical_session_slug(flow: flow, state: state)
+      @session = self.class.canonical_session_slug(flow: flow, state: state)
 
       Stealth::Logger.l(topic: "session", message: "User #{user_id}: setting session to #{flow}->#{state}")
       $redis.set(user_id, session)
@@ -85,7 +85,7 @@ module Stealth
 
       new_state = self.state + steps
       new_session = Stealth::Session.new(user_id: self.user_id)
-      new_session.session = canonical_session_slug(flow: self.flow_string, state: new_state)
+      new_session.session = self.class.canonical_session_slug(flow: self.flow_string, state: new_state)
 
       new_session
     end
@@ -100,22 +100,23 @@ module Stealth
       end
     end
 
-    private
     def self.is_a_session_string?(string)
       session_regex = /(.+)(#{SLUG_SEPARATOR})(.+)/
       !!string.match(session_regex)
     end
 
-      def canonical_session_slug(flow:, state:)
-        [flow, state].join(SLUG_SEPARATOR)
-      end
+    def self.canonical_session_slug(flow:, state:)
+      [flow, state].join(SLUG_SEPARATOR)
+    end
+
+    private
 
       def previous_session_key(user_id:)
         [user_id, 'previous'].join('-')
       end
 
       def store_current_to_previous(flow:, state:)
-        new_session = canonical_session_slug(flow: flow, state: state)
+        new_session = self.class.canonical_session_slug(flow: flow, state: state)
 
         # Prevent previous_session from becoming current_session
         if new_session == session

--- a/spec/controller/catch_all_spec.rb
+++ b/spec/controller/catch_all_spec.rb
@@ -62,12 +62,14 @@ describe "Stealth::Controller::CatchAll" do
     end
 
     it "should step_to catch_all->level1 when a StandardError is raised" do
+      controller.current_session.session = Stealth::Session.canonical_session_slug(flow: 'vader', state: 'my_action')
       controller.action(action: :my_action)
       expect(controller.current_session.flow_string).to eq("catch_all")
       expect(controller.current_session.state_string).to eq("level1")
     end
 
     it "should step_to catch_all->level1 when an action doesn't progress the flow" do
+      controller.current_session.session = Stealth::Session.canonical_session_slug(flow: 'vader', state: 'my_action2')
       controller.action(action: :my_action2)
       expect(controller.current_session.flow_string).to eq("catch_all")
       expect(controller.current_session.state_string).to eq("level1")
@@ -98,4 +100,3 @@ describe "Stealth::Controller::CatchAll" do
     end
   end
 end
-

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -107,4 +107,21 @@ describe "Stealth::Session" do
       expect(new_session.state_string).to eq('error')
     end
   end
+
+  describe "self.is_a_session_string?" do
+    it "should return false for state strings" do
+      session_string = 'say_hello'
+      expect(Stealth::Session.is_a_session_string?(session_string)).to be false
+    end
+
+    it "should return false for an incomplete session string" do
+      session_string = 'hello->'
+      expect(Stealth::Session.is_a_session_string?(session_string)).to be false
+    end
+
+    it "should return true for a complete session string" do
+      session_string = 'hello->say_hello'
+      expect(Stealth::Session.is_a_session_string?(session_string)).to be true
+    end
+  end
 end


### PR DESCRIPTION
This also updates `fails_to` to support a session key as an argument. This allows a `fails_to` to specify a completely different flow than where the failure occurred.

Fixes #95 
