### PR TITLE
Server tweaks

### DIFF
--- a/lib/stealth/logger.rb
+++ b/lib/stealth/logger.rb
@@ -5,14 +5,15 @@ module Stealth
   class Logger
 
     COLORS = ::Hash[
-      black:   30,
-      red:     31,
-      green:   32,
-      yellow:  33,
-      blue:    34,
-      magenta: 35,
-      cyan:    36,
-      gray:    37,
+      black:        30,
+      red:          31,
+      green:        32,
+      yellow:       33,
+      blue:         34,
+      magenta:      35,
+      cyan:         36,
+      gray:         37,
+      light_cyan:   96
     ].freeze
 
     def self.color_code(code)
@@ -41,6 +42,8 @@ module Stealth
         colorize(topic_string, color: :blue)
       when :smooch
         colorize(topic_string, color: :magenta)
+      when :alexa
+        colorize(topic_string, color: :light_cyan)
       when :catch_all
         colorize(topic_string, color: :red)
       else

--- a/lib/stealth/server.rb
+++ b/lib/stealth/server.rb
@@ -33,7 +33,7 @@ module Stealth
       Stealth::Logger.l(topic: "incoming", message: "Received webhook from #{params[:service]}")
 
       # JSON params need to be parsed and added to the params
-      if request.env['CONTENT_TYPE'] == 'application/json'
+      if request.env['CONTENT_TYPE'].match(/application\/json/i)
         json_params = MultiJson.load(request.body.read)
         params.merge!(json_params)
       end


### PR DESCRIPTION
`CONTENT-TYPE` can be specified as `application/json; charset=utf8`. In these cases we aren't properly decoding the body.