### PR TITLE
Add params hash to session

### DIFF
--- a/lib/stealth/flow/specification.rb
+++ b/lib/stealth/flow/specification.rb
@@ -43,7 +43,8 @@ module Stealth
             else
               session.session = Stealth::Session.canonical_session_slug(
                 flow: flow_name,
-                state: specified_state
+                state: specified_state,
+                params: {}
               )
             end
 

--- a/lib/stealth/session.rb
+++ b/lib/stealth/session.rb
@@ -36,7 +36,7 @@ module Stealth
     end
 
     def params
-      (params_json.blank? || params_json == "{}") ? {} : JSON.load(params_json)
+      (params_json.blank? || params_json == "{}") ? {} : ActiveSupport::HashWithIndifferentAccess.new(JSON.load(params_json))
     end
 
     def flow_string

--- a/spec/controller/catch_all_spec.rb
+++ b/spec/controller/catch_all_spec.rb
@@ -62,14 +62,14 @@ describe "Stealth::Controller::CatchAll" do
     end
 
     it "should step_to catch_all->level1 when a StandardError is raised" do
-      controller.current_session.session = Stealth::Session.canonical_session_slug(flow: 'vader', state: 'my_action')
+      controller.current_session.session = Stealth::Session.canonical_session_slug(flow: 'vader', state: 'my_action', params: {})
       controller.action(action: :my_action)
       expect(controller.current_session.flow_string).to eq("catch_all")
       expect(controller.current_session.state_string).to eq("level1")
     end
 
     it "should step_to catch_all->level1 when an action doesn't progress the flow" do
-      controller.current_session.session = Stealth::Session.canonical_session_slug(flow: 'vader', state: 'my_action2')
+      controller.current_session.session = Stealth::Session.canonical_session_slug(flow: 'vader', state: 'my_action2', params: {})
       controller.action(action: :my_action2)
       expect(controller.current_session.flow_string).to eq("catch_all")
       expect(controller.current_session.state_string).to eq("level1")
@@ -100,7 +100,7 @@ describe "Stealth::Controller::CatchAll" do
     end
 
     it "should NOT run the catch_all if do_nothing is called" do
-      controller.current_session.session = Stealth::Session.canonical_session_slug(flow: 'vader', state: 'my_action3')
+      controller.current_session.session = Stealth::Session.canonical_session_slug(flow: 'vader', state: 'my_action3', params: {})
       controller.action(action: :my_action3)
       expect(controller.current_session.flow_string).to eq("vader")
       expect(controller.current_session.state_string).to eq("my_action3")

--- a/spec/controller/controller_spec.rb
+++ b/spec/controller/controller_spec.rb
@@ -72,10 +72,11 @@ describe "Stealth::Controller" do
       expect(controller.current_user_id).to eq(facebook_message.sender_id)
     end
 
-    it "should make params available in current_session.params" do
-      controller.current_session.set(flow: 'mr_tron', state: 'other_action', params: { 'key' => 'value' })
+    it "should make indifferent access hash params available in current_session.params" do
+      controller.current_session.set(flow: 'mr_tron', state: 'other_action', params: { key: 'value' })
 
-      expect(controller.current_session.params).to eq({ 'key' => 'value' })
+      expect(controller.current_session.params['key']).to eq 'value'
+      expect(controller.current_session.params[:key]).to eq 'value'
     end
 
     it "should make the message available in current_message.message" do
@@ -172,11 +173,12 @@ describe "Stealth::Controller" do
       controller.step_to state: "other_action3"
     end
 
-    it "should call a controller's corresponding action with params set on current_session when a state, flow and params is provided" do
+    it "should call a controller's corresponding action with params set on current_session when a state, flow and indifferent access hash params is provided" do
       expect_any_instance_of(MrRobotsController).to receive(:my_action3)
-      controller.step_to flow: "mr_robot", state: "my_action3", params: { 'key' => 'value' }
+      controller.step_to flow: "mr_robot", state: "my_action3", params: { key: 'value'}
       
-      expect(controller.current_session.params).to eq({ 'key' => 'value' })
+      expect(controller.current_session.params['key']).to eq 'value'
+      expect(controller.current_session.params[:key]).to eq 'value'
     end
 
     it "should call a controller's corresponding action when a session is provided" do
@@ -222,22 +224,24 @@ describe "Stealth::Controller" do
     it "should update session to controller's corresponding action when a state, flow and params is provided" do
       expect_any_instance_of(MrRobotsController).to_not receive(:my_action3)
 
-      controller.update_session_to flow: "mr_robot", state: "my_action3", params: { 'key' => 'value' }
+      controller.update_session_to flow: "mr_robot", state: "my_action3", params: { key: 'value' }
       expect(controller.current_session.flow_string).to eq('mr_robot')
       expect(controller.current_session.state_string).to eq('my_action3')
-      expect(controller.current_session.params).to eq({ 'key' => 'value' })
+      expect(controller.current_session.params['key']).to eq 'value'
+      expect(controller.current_session.params[:key]).to eq 'value'
     end
 
     it "should update session to controller's corresponding action when a session is provided" do
       expect_any_instance_of(MrRobotsController).to_not receive(:my_action3)
 
       session = Stealth::Session.new(user_id: controller.current_session_id)
-      session.set(flow: 'mr_robot', state: 'my_action3', params: { 'key' => 'value' })
+      session.set(flow: 'mr_robot', state: 'my_action3', params: { key: 'value' })
 
       controller.update_session_to session: session
       expect(controller.current_session.flow_string).to eq('mr_robot')
       expect(controller.current_session.state_string).to eq('my_action3')
-      expect(controller.current_session.params).to eq({ 'key' => 'value' })
+      expect(controller.current_session.params['key']).to eq 'value'
+      expect(controller.current_session.params[:key]).to eq 'value'
     end
 
     it "should accept flow and string specified as symbols" do
@@ -307,11 +311,11 @@ describe "Stealth::Controller" do
         controller.current_session_id,
         'mr_robot',
         'my_action3',
-        { 'key' => 'value' }
+        { key: 'value' }
       )
 
       expect {
-        controller.step_to_in 100.seconds, flow: 'mr_robot', state: "my_action3", params: { 'key' => 'value' }
+        controller.step_to_in 100.seconds, flow: 'mr_robot', state: "my_action3", params: { key: 'value' }
       }.to_not change(controller.current_session, :get)
     end
 
@@ -319,7 +323,7 @@ describe "Stealth::Controller" do
       expect_any_instance_of(MrRobotsController).to_not receive(:my_action)
 
       session = Stealth::Session.new(user_id: controller.current_session_id)
-      session.set(flow: 'mr_robot', state: 'my_action3', params: { 'key' => 'value' })
+      session.set(flow: 'mr_robot', state: 'my_action3', params: { key: 'value' })
 
       expect(Stealth::ScheduledReplyJob).to receive(:perform_in).with(
         100.seconds,
@@ -327,7 +331,7 @@ describe "Stealth::Controller" do
         controller.current_session_id,
         'mr_robot',
         'my_action3',
-        { 'key' => 'value' }
+        { key: 'value' }
       )
 
       expect {
@@ -413,11 +417,11 @@ describe "Stealth::Controller" do
         controller.current_session_id,
         'mr_robot',
         'my_action3',
-        { 'key' => 'value' }
+        { key: 'value' }
       )
 
       expect {
-        controller.step_to_at future_timestamp, flow: 'mr_robot', state: "my_action3", params: { 'key' => 'value' }
+        controller.step_to_at future_timestamp, flow: 'mr_robot', state: "my_action3", params: { key: 'value' }
       }.to_not change(controller.current_session, :get)
     end
 
@@ -425,7 +429,7 @@ describe "Stealth::Controller" do
       expect_any_instance_of(MrRobotsController).to_not receive(:my_action)
 
       session = Stealth::Session.new(user_id: controller.current_session_id)
-      session.set(flow: 'mr_robot', state: 'my_action3', params: { 'key' => 'value' })
+      session.set(flow: 'mr_robot', state: 'my_action3', params: { key: 'value' })
 
       expect(Stealth::ScheduledReplyJob).to receive(:perform_at).with(
         future_timestamp,
@@ -433,7 +437,7 @@ describe "Stealth::Controller" do
         controller.current_session_id,
         'mr_robot',
         'my_action3',
-        { 'key' => 'value' }
+        { key: 'value' }
       )
 
       expect {

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -69,7 +69,8 @@ describe "Stealth::Session" do
     end
 
     it "should return the params" do
-      expect(session.params).to eq({ "key" => "value" })
+      expect(session.params["key"]).to eq "value"
+      expect(session.params[:key]).to eq "value"
     end
 
     it "should return the flow_string" do


### PR DESCRIPTION
Add simple params hash to session. You can add params anywhere flow and state are used. The params hash will then be available on the `current_session.params`.
For example: `step_to flow: 'some_flow', state: 'some_state', params: { 'some_key' => 'some_value' }`