### PR TITLE
Stealth::Configuration returns nil for unknown keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [Logging] Add option, `Stealth.config.transcript_logging`, to log incoming and outgoing messages.
 * [Server] The only HTTP header passed along to `handle_message_job` is now `HTTP_HOST`.
 * [Controllers] Added `set_back_to` and `step_back` to allow user specified "redirect back". Useful for multi-state transitions that would otherwise not be possible with just `previous_session`.
+* [Configuration] Stealth::Configuration now returns `nil` for a configuration option that is missing. It still returns a `NoMethodError` if attempting to access a key from a parent node that is also missing.
 
 ## Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stealth (2.5.3)
+    stealth (2.0.0.beta1)
       activesupport (~> 5.2)
       multi_json (~> 1.12)
       puma (>= 3.10, < 5.0)
@@ -26,9 +26,9 @@ GEM
     mock_redis (0.21.0)
     multi_json (1.13.1)
     mustermann (1.0.3)
-    nio4r (2.5.1)
+    nio4r (2.4.0)
     oj (3.8.1)
-    puma (4.1.1)
+    puma (4.1.0)
       nio4r (~> 2.0)
     rack (2.0.7)
     rack-protection (2.0.7)

--- a/lib/stealth/configuration.rb
+++ b/lib/stealth/configuration.rb
@@ -1,8 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
 
-require 'thread'
-
 module Stealth
   class Configuration < Hash
 
@@ -20,7 +18,6 @@ module Stealth
       if setter?(method)
         self[key] = args.first
       else
-        super(method, args) && return unless key?(key)
         self[key]
       end
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -29,6 +29,14 @@ describe "Stealth::Configuration" do
     it "should handle multiple keys at the root level" do
       expect(config.twilio_sms.account_sid).to eq parsed_config['twilio_sms']['account_sid']
     end
+
+    it "should return nil if the key is not present at the node" do
+      expect(config.twilio_sms.api_key).to be nil
+    end
+
+    it "should raise a NoMethodError when accessing multi-levels of missing nodes" do
+      expect { config.slack.api_key }.to raise_error(NoMethodError)
+    end
   end
 
   describe "config files with ERB" do


### PR DESCRIPTION
So given this `services.yml`:

```yaml
default: &default
  facebook:
    verify_token: c68823f4-7259-4600-b9f0-382a67260757
    challenge: pOmQ7iq4ZA1hK6TbO7yrVZCmygVjfIiEIYaIZAlEveOAzY4UKb
    page_access_token: EAADhbJruBbMBAKY9bnesHh9eM09ZAHjGsCQtNdvuZClZCFtyIXdFdIQI2mV0PJM910Qyn3lNNhZBPZB54zLRhDNmeIkDz9myS25CTy0kFxHjQCXJxz5oeZCD60VWdAZAFxbeDKvF8eF28qDHAI4wkGc3jvVhjFISKmmFRRM6goUeAZDZD
    setup:
      greeting: # Greetings are broken up by locale
        - locale: default
          text: "Welcome to the Stealth bot 🤖"
      persistent_menu:
        - type: payload
          text: Main Menu
          payload: main_menu
        - type: url
          text: Visit our website
          url: https://example.com
        - type: call
          text: Call us
          payload: "+17345551234"
  twilio:
    account_sid: BC6f4bd46307054c84fdff70badcd9ef5d
    auth_token: 4af73d27d92cff6391611a9c976725cc
```

Before this change calling `Stealth.config.twilio.api_key` would result in a `NoMethodError` being raised. I don't think this fits with the goal of `Stealth::Configuration` and has always tripped me up.

Ideally, `Stealth.config.twilio.api_key` should return a `nil` but something like `Stealth.config.slack.api_key` should still raise an error since we've gone two-levels deep without a match.

This PR changes that.