### PR TITLE
Remove support for Ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,51 +1,6 @@
 version: 2
 
 jobs:
-  ruby_2_4:
-    docker:
-      - image: circleci/ruby:2.4-node-browsers
-        environment:
-          STEALTH_ENV: test
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
-      - run:
-          name: install dependencies
-          command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      # run tests!
-      - run:
-          name: run tests
-          command: |
-            mkdir /tmp/test-results
-            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
-            bundle exec rspec --format progress \
-                --format RspecJunitFormatter \
-                --out /tmp/test-results/rspec.xml \
-                --format progress \
-                -- \
-                $TEST_FILES
-      # collect reports
-      - store_test_results:
-          path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
   ruby_2_5:
     docker:
       - image: circleci/ruby:2.5-node-browsers
@@ -144,6 +99,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - ruby_2_4
       - ruby_2_5
       - ruby_2_6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 ## Deprecations
 
 * [Controllers] current_user_id has now been completely removed since becoming deprecated in 1.1.0.
+* [Ruby] MRI 2.4 is no longer supported as we depend on ActiveSupport 6.0 now. Rails 6.0 only supports Ruby MRI 2.5+.
 
 # Changelog for Stealth v1.1.5
 


### PR DESCRIPTION
MRI 2.4 is no longer supported as we depend on ActiveSupport 6.0 now. Rails 6.0 only supports Ruby MRI 2.5+.