### PR TITLE
Custom replies should support sub-dir nesting

### DIFF
--- a/lib/stealth/controller/replies.rb
+++ b/lib/stealth/controller/replies.rb
@@ -130,8 +130,9 @@ module Stealth
             selected_preprocessor = :none
 
             if custom_reply.present?
-              _dir, _file = custom_reply.split(File::SEPARATOR)
-              _file = "#{_file}.yml"
+              dir_and_file = custom_reply.rpartition(File::SEPARATOR)
+              _dir = dir_and_file.first
+              _file = "#{dir_and_file.last}.yml"
               _replies_dir = [*self._replies_path, _dir]
               possible_filenames = reply_filenames(_file)
               reply_file_path = File.join(_replies_dir, _file)

--- a/spec/controller/replies_spec.rb
+++ b/spec/controller/replies_spec.rb
@@ -55,6 +55,10 @@ describe "Stealth::Controller replies" do
       send_replies custom_reply: 'messages/say_offer'
     end
 
+    def say_nested_custom_reply
+      send_replies custom_reply: 'messages/sub1/sub2/say_nested'
+    end
+
     def say_inline_reply
       reply = [
         { 'reply_type' => 'text', 'text' => 'Hi, Morty. Welcome to Stealth bot...' },
@@ -227,6 +231,15 @@ describe "Stealth::Controller replies" do
 
       expect(controller).to receive(:sleep).exactly(1).times.with(2.0)
       controller.say_custom_reply
+    end
+
+    it "should correctly load from sub-dirs" do
+      expect(stubbed_handler).to receive(:text).exactly(3).times
+      expect(stubbed_handler).to receive(:delay).exactly(2).times
+      expect(stubbed_client).to receive(:transmit).exactly(5).times
+
+      expect(controller).to receive(:sleep).exactly(2).times.with(2.0)
+      controller.say_nested_custom_reply
     end
   end
 

--- a/spec/replies/messages/sub1/sub2/say_nested.yml
+++ b/spec/replies/messages/sub1/sub2/say_nested.yml
@@ -1,0 +1,10 @@
+- reply_type: text
+  text: "Hi, Morty. Welcome to Stealth bot..."
+- reply_type: delay
+  duration: 2
+- reply_type: text
+  text: "We offer users an awesome Ruby framework for building chat bots."
+- reply_type: delay
+  duration: 2
+- reply_type: text
+  text: "This reply was nested."


### PR DESCRIPTION
Currently custom replies fail when they are nested in one or more sub directories.