### PR TITLE
Remove explicit zeitwerk dependency

### DIFF
--- a/stealth.gemspec
+++ b/stealth.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'thor', '~> 0.20'
   s.add_dependency 'multi_json', '~> 1.12'
   s.add_dependency 'sidekiq', '~> 6.0'
-  s.add_dependency 'zeitwerk', '~> 2.2'
   s.add_dependency 'activesupport', '~> 6.0'
 
   s.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
ActiveSupport 6.0+ already requires zeitwerk now.