### PR TITLE
Production env needs access to autoload paths

### DIFF
--- a/lib/stealth/base.rb
+++ b/lib/stealth/base.rb
@@ -68,12 +68,8 @@ module Stealth
     config.transcript_logging = false
     config.hot_reload = Stealth.env.development?
     config.eager_load = Stealth.env.production?
-
-    # Avoid loading the array in production
-    if Stealth.env.development?
-      config.autoload_paths = Stealth.default_autoload_paths
-      config.autoload_ignore_paths = []
-    end
+    config.autoload_paths = Stealth.default_autoload_paths
+    config.autoload_ignore_paths ||= []
   end
 
   # Loads the services.yml configuration unless one has already been loaded


### PR DESCRIPTION
Fixes bug with new hot-reloader preventing production environments from loading autoload paths.