### PR TITLE
Fix console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 * [Server] The only HTTP header passed along to `handle_message_job` is now `HTTP_HOST`.
 * [Controllers] Added `set_back_to` and `step_back` to allow user specified "redirect back". Useful for multi-state transitions that would otherwise not be possible with just `previous_session`.
 * [Configuration] Stealth::Configuration now returns `nil` for a configuration option that is missing. It still returns a `NoMethodError` if attempting to access a key from a parent node that is also missing.
+* [Reloading] Bots in development mode now hot reload! It's no longer necessary to stop your local server.
+* [Production] Production bots now eager load bot code to improve copy-on-write performance. The `puma.rb` config has been updated with instructions for multiple workers.
 
 ## Bug Fixes
 

--- a/lib/stealth/base.rb
+++ b/lib/stealth/base.rb
@@ -102,12 +102,19 @@ module Stealth
     load_services_config(services_yaml)
   end
 
+  def self.load_bot!
+    @bot_reloader ||= begin
+      bot_reloader = Stealth::Reloader.new
+      bot_reloader.load_bot!
+      bot_reloader
+    end
+  end
+
   def self.load_environment
     require File.join(Stealth.root, 'config', 'boot')
     require_directory('config/initializers')
 
-    @bot_reloader = Stealth::Reloader.new
-    @bot_reloader.load_bot!
+    load_bot!
 
     Sidekiq.options[:reloader] = Stealth.bot_reloader
 

--- a/lib/stealth/cli.rb
+++ b/lib/stealth/cli.rb
@@ -80,7 +80,6 @@ module Stealth
 
     $ > stealth console --engine=pry
     EOS
-    method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
     method_option :engine, desc: "Choose a specific console engine: (#{Stealth::Commands::Console::ENGINES.keys.join('/')})"
     method_option :help, desc: 'Displays the usage method'
     def console

--- a/lib/stealth/commands/console.rb
+++ b/lib/stealth/commands/console.rb
@@ -53,7 +53,7 @@ module Stealth
         # Add convenience methods to the main:Object binding
         TOPLEVEL_BINDING.eval('self').__send__(:include, CodeReloading)
 
-        Stealth.load_environment
+        Stealth.boot
       end
 
       def engine_lookup


### PR DESCRIPTION
After moving to `zeitwerk`, the console seems to have broken due to the way we boot the bot in console. These changes update the way the bot loaded so as to load the config settings as well prevent two reloaders from becoming instantiated.