### PR TITLE
Include the catch_all_reason in the service_message

### DIFF
--- a/lib/stealth/controller/controller.rb
+++ b/lib/stealth/controller/controller.rb
@@ -85,6 +85,13 @@ module Stealth
             topic: "catch_all",
             message: [e.message, e.backtrace.join("\n")].join("\n")
           )
+
+          # Store the reason so it can be accessed by the CatchAllsController
+          current_message.catch_all_reason = {
+            err: e.class,
+            err_msg: e.message
+          }
+
           run_catch_all(reason: e.message)
         end
       end

--- a/lib/stealth/controller/messages.rb
+++ b/lib/stealth/controller/messages.rb
@@ -100,7 +100,7 @@ module Stealth
 
           if raise_on_mismatch
             raise(
-              StandardError,
+              Stealth::Errors::MessageNotRecognized,
               "The reply '#{current_message.message}' was not recognized."
             )
           else
@@ -127,7 +127,7 @@ module Stealth
               log_nlp_result
 
               raise(
-                StandardError,
+                Stealth::Errors::MessageNotRecognized,
                 "Encountered #{match_count} entity matches of type #{entity.inspect} and expected 1. To allow, set fuzzy_match to true."
               )
             else
@@ -157,7 +157,7 @@ module Stealth
                 log_nlp_result
                 leftover_count = nlp_entities[entity].size
                 raise(
-                  StandardError,
+                  Stealth::Errors::MessageNotRecognized,
                   "Encountered #{leftover_count} additional entity matches of type #{entity.inspect} for match #{entities.inspect}. To allow, set fuzzy_match to true."
                 )
               end

--- a/lib/stealth/errors.rb
+++ b/lib/stealth/errors.rb
@@ -34,6 +34,9 @@ module Stealth
     class ReplyNotFound < Errors
     end
 
+    class MessageNotRecognized < Errors
+    end
+
     class FlowError < Errors
     end
 

--- a/lib/stealth/service_message.rb
+++ b/lib/stealth/service_message.rb
@@ -5,7 +5,8 @@ module Stealth
   class ServiceMessage
 
     attr_accessor :sender_id, :target_id, :timestamp, :service, :message,
-                  :location, :attachments, :payload, :referral, :nlp_result
+                  :location, :attachments, :payload, :referral, :nlp_result,
+                  :catch_all_reason
 
     def initialize(service:)
       @service = service

--- a/spec/controller/messages_spec.rb
+++ b/spec/controller/messages_spec.rb
@@ -57,18 +57,18 @@ describe Stealth::Controller::Messages do
       ).to eq('woot')
     end
 
-    it "should raise StandardError if a response was not matched" do
+    it "should raise Stealth::Errors::MessageNotRecognized if a response was not matched" do
       test_controller.current_message.message = "uh oh"
       expect {
         test_controller.get_match(['nice', 'woot'])
-      }.to raise_error(StandardError)
+      }.to raise_error(Stealth::Errors::MessageNotRecognized)
     end
 
-    it "should raise StandardError if an SMS quick reply was not matched" do
+    it "should raise Stealth::Errors::MessageNotRecognized if an SMS quick reply was not matched" do
       test_controller.current_message.message = "C"
       expect {
         test_controller.get_match(['nice', 'woot'])
-      }.to raise_error(StandardError)
+      }.to raise_error(Stealth::Errors::MessageNotRecognized)
     end
 
     describe "entity detection" do
@@ -99,14 +99,14 @@ describe Stealth::Controller::Messages do
           ).to eq(test_controller.nlp_result.entities[:number].first)
         end
 
-        it 'should raise StandardError if more than one :number entity is returned and fuzzy_match=false' do
+        it 'should raise Stealth::Errors::MessageNotRecognized if more than one :number entity is returned and fuzzy_match=false' do
           allow(test_controller).to receive(:perform_nlp!).and_return(double_number_nlp_result)
           test_controller.nlp_result = double_number_nlp_result
 
           test_controller.current_message.message = "hi"
           expect {
             test_controller.get_match(['nice', :number], fuzzy_match: false)
-          }.to raise_error(StandardError, "Encountered 2 entity matches of type :number and expected 1. To allow, set fuzzy_match to true.")
+          }.to raise_error(Stealth::Errors::MessageNotRecognized, "Encountered 2 entity matches of type :number and expected 1. To allow, set fuzzy_match to true.")
         end
       end
 
@@ -161,35 +161,35 @@ describe Stealth::Controller::Messages do
           ).to eq([89, 'scores'])
         end
 
-        it 'should raise StandardError if more than one :number entity is returned and fuzzy_match=false' do
+        it 'should raise Stealth::Errors::MessageNotRecognized if more than one :number entity is returned and fuzzy_match=false' do
           allow(test_controller).to receive(:perform_nlp!).and_return(triple_number_nlp_result)
           test_controller.nlp_result = triple_number_nlp_result
 
           test_controller.current_message.message = "hi"
           expect {
             test_controller.get_match(['nice', :number], fuzzy_match: false)
-          }.to raise_error(StandardError, "Encountered 3 entity matches of type :number and expected 1. To allow, set fuzzy_match to true.")
+          }.to raise_error(Stealth::Errors::MessageNotRecognized, "Encountered 3 entity matches of type :number and expected 1. To allow, set fuzzy_match to true.")
         end
 
-        it 'should raise StandardError if more than two :number entities are returned and fuzzy_match=false' do
+        it 'should raise Stealth::Errors::MessageNotRecognized if more than two :number entities are returned and fuzzy_match=false' do
           allow(test_controller).to receive(:perform_nlp!).and_return(triple_number_nlp_result)
           test_controller.nlp_result = triple_number_nlp_result
 
           test_controller.current_message.message = "hi"
           expect {
             test_controller.get_match(['nice', [:number, :number]], fuzzy_match: false)
-          }.to raise_error(StandardError, "Encountered 1 additional entity matches of type :number for match [:number, :number]. To allow, set fuzzy_match to true.")
+          }.to raise_error(Stealth::Errors::MessageNotRecognized, "Encountered 1 additional entity matches of type :number for match [:number, :number]. To allow, set fuzzy_match to true.")
         end
       end
     end
 
     describe "mismatch" do
       describe 'raise_on_mismatch: true' do
-        it "should raise a StandardError" do
+        it "should raise a Stealth::Errors::MessageNotRecognized" do
           test_controller.current_message.message = 'C'
           expect {
             test_controller.get_match(['nice', 'woot'])
-          }.to raise_error(StandardError)
+          }.to raise_error(Stealth::Errors::MessageNotRecognized)
         end
 
         it "should NOT log if an nlp_result is not present" do
@@ -197,7 +197,7 @@ describe Stealth::Controller::Messages do
           expect(Stealth::Logger).to_not receive(:l)
           expect {
             test_controller.get_match(['nice', 'woot'])
-          }.to raise_error(StandardError)
+          }.to raise_error(Stealth::Errors::MessageNotRecognized)
         end
 
         it "should log if an nlp_result is present" do
@@ -214,16 +214,16 @@ describe Stealth::Controller::Messages do
 
           expect {
             test_controller.get_match(['nice', 'woot'])
-          }.to raise_error(StandardError)
+          }.to raise_error(Stealth::Errors::MessageNotRecognized)
         end
       end
 
       describe 'raise_on_mismatch: false' do
-        it "should not raise a StandardError" do
+        it "should not raise a Stealth::Errors::MessageNotRecognized" do
           test_controller.current_message.message = 'C'
           expect {
             test_controller.get_match(['nice', 'woot'], raise_on_mismatch: false)
-          }.to_not raise_error(StandardError)
+          }.to_not raise_error(Stealth::Errors::MessageNotRecognized)
         end
 
         it "should return the original message" do
@@ -320,7 +320,7 @@ describe Stealth::Controller::Messages do
       end
     end
 
-    it "should raise StandardError if the reply does not match" do
+    it "should raise Stealth::Errors::MessageNotRecognized if the reply does not match" do
       test_controller.current_message.message = "C"
       x = 0
       expect {
@@ -328,7 +328,7 @@ describe Stealth::Controller::Messages do
           'Buy' => proc { x += 1 },
           'Refinance' => proc { x += 2 }
         )
-      }.to raise_error(StandardError)
+      }.to raise_error(Stealth::Errors::MessageNotRecognized)
     end
 
     it "should NOT log if an nlp_result is not present" do
@@ -341,7 +341,7 @@ describe Stealth::Controller::Messages do
           'Buy' => proc { x += 1 },
           'Refinance' => proc { x += 2 }
         )
-      }.to raise_error(StandardError)
+      }.to raise_error(Stealth::Errors::MessageNotRecognized)
     end
 
     it "should log if an nlp_result is present" do
@@ -362,7 +362,7 @@ describe Stealth::Controller::Messages do
           'Buy' => proc { x += 1 },
           'Refinance' => proc { x += 2 }
         )
-      }.to raise_error(StandardError)
+      }.to raise_error(Stealth::Errors::MessageNotRecognized)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,12 +14,15 @@ require 'mock_redis'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 $redis = MockRedis.new
+$services_yml = File.read(File.join(File.dirname(__FILE__), 'support', 'services.yml'))
 
 RSpec.configure do |config|
   ENV['STEALTH_ENV'] = 'test'
 
   config.before(:each) do |example|
     Sidekiq::Testing.fake!
+
+    Stealth.load_services_config!($services_yml)
   end
 
   config.expect_with :rspec do |expectations|

--- a/spec/support/controllers/vaders_controller.rb
+++ b/spec/support/controllers/vaders_controller.rb
@@ -10,4 +10,15 @@ class VadersController < Stealth::Controller
   def my_action3
     do_nothing
   end
+
+  def action_with_unrecognized_msg
+    handle_message(
+      'hello' => proc { puts "Hello world!" },
+      'bye' => proc { puts "Goodbye world!" }
+    )
+  end
+
+  def action_with_unrecognized_match
+    match = get_match(['hello', 'bye'])
+  end
 end


### PR DESCRIPTION
This adds the error class and the message to the `service_message`. This allows one to access the `catch_all_reason` from within the `CatchAllsController` as such:

```ruby
 class CatchAllsController < Stealth::Controller
    def level1
      current_message.catch_all_reason
      # { err: StandardError, err_msg: 'The message from the error' } 
      do_nothing
    end
end
```

This PR also standardizes the errors coming from `get_match` and `handle_message` so they both only ever return a `Stealth::Errors::MessageNotRecognized` error. This allows one to distinguish between "I didn't understand what you said" errors and the errors caused by service failures, bugs, etc.

Fixes #197 