### PR TITLE
Improve NLP logging

### DIFF
--- a/lib/stealth/base.rb
+++ b/lib/stealth/base.rb
@@ -71,6 +71,7 @@ module Stealth
     config.autoload_paths = Stealth.default_autoload_paths
     config.autoload_ignore_paths ||= []
     config.nlp_integration = nil
+    config.log_all_nlp_results = false
   end
 
   # Loads the services.yml configuration unless one has already been loaded

--- a/lib/stealth/controller/messages.rb
+++ b/lib/stealth/controller/messages.rb
@@ -172,7 +172,7 @@ module Stealth
           if nlp_result.present?
             Stealth::Logger.l(
               topic: :nlp,
-              message: "NLP Result: #{nlp_result.parsed_result.inspect}"
+              message: "User #{current_session_id} -> NLP Result: #{nlp_result.parsed_result.inspect}"
             )
           end
         end

--- a/lib/stealth/controller/nlp.rb
+++ b/lib/stealth/controller/nlp.rb
@@ -28,7 +28,7 @@ module Stealth
             if Stealth.config.log_all_nlp_results
               Stealth::Logger.l(
                 topic: :nlp,
-                message: "User #{current_session_id} -> NLP result: #{@nlp_result.parsed_result.inspect}"
+                message: "User #{current_session_id} -> NLP Result: #{@nlp_result.parsed_result.inspect}"
               )
             end
 

--- a/lib/stealth/controller/nlp.rb
+++ b/lib/stealth/controller/nlp.rb
@@ -25,6 +25,13 @@ module Stealth
               query: current_message.message
             )
 
+            if Stealth.config.log_all_nlp_results
+              Stealth::Logger.l(
+                topic: :nlp,
+                message: "User #{current_session_id} -> NLP result: #{@nlp_result.parsed_result.inspect}"
+              )
+            end
+
             @nlp_result
           end
         end

--- a/lib/stealth/controller/nlp.rb
+++ b/lib/stealth/controller/nlp.rb
@@ -10,6 +10,11 @@ module Stealth
       included do
         # Memoized in order to prevent multiple requests to the NLP provider
         def perform_nlp!
+          Stealth::Logger.l(
+            topic: :nlp,
+            message: "User #{current_session_id} -> Performing NLP."
+          )
+
           unless Stealth.config.nlp_integration.present?
             raise Stealth::Errors::ConfigurationError, "An NLP integration has not yet been configured (Stealth.config.nlp_integration)"
           end


### PR DESCRIPTION
We weren't attaching the user's `session_id` with previous logging and so it became difficult to associate an NLP action with a specific conversation. This adds a new option as well to log ALL NLP results, not just the failures. This is helpful I think for new deployments.