### PR TITLE
Make dev jumps resilient to American dates

### DIFF
--- a/lib/stealth/controller/dev_jumps.rb
+++ b/lib/stealth/controller/dev_jumps.rb
@@ -5,6 +5,8 @@ module Stealth
   class Controller
     module DevJumps
 
+      DEV_JUMP_REGEX = /\A\/(.*)\/(.*)\z|\A\/\/(.*)\z|\A\/(.*)\z/
+
       extend ActiveSupport::Concern
 
       included do
@@ -12,7 +14,7 @@ module Stealth
 
         def dev_jump_detected?
           if Stealth.env.development?
-            if current_message.message&.match(/\/(.*)\/(.*)|\/\/(.*)|\/(.*)/)
+            if current_message.message&.match(DEV_JUMP_REGEX)
               handle_dev_jump
               return true
             end

--- a/spec/controller/controller_spec.rb
+++ b/spec/controller/controller_spec.rb
@@ -711,6 +711,20 @@ describe "Stealth::Controller" do
         expect(controller.send(:dev_jump_detected?)).to be false
       end
 
+      it "should return false if the message looks like an American date" do
+        allow(Stealth).to receive(:env).and_return(dev_env)
+        controller.current_message.message = '1/23/84'
+        expect(Stealth.env.development?).to be true
+        expect(controller.send(:dev_jump_detected?)).to be false
+      end
+
+      it "should return false if the message looks like an American date that is zero padded" do
+        allow(Stealth).to receive(:env).and_return(dev_env)
+        controller.current_message.message = '01/23/1984'
+        expect(Stealth.env.development?).to be true
+        expect(controller.send(:dev_jump_detected?)).to be false
+      end
+
       describe "with a dev jump message" do
         before(:each) do
           expect(controller).to receive(:handle_dev_jump).and_return(true)


### PR DESCRIPTION
Previously American dates would cause Stealth to think a dev jump was entered.