### PR TITLE
Simplify session locking/unlocking

### DIFF
--- a/lib/stealth/controller/catch_all.rb
+++ b/lib/stealth/controller/catch_all.rb
@@ -27,11 +27,8 @@ module Stealth
             else
               # We are out of bounds, do nothing to prevent an infinite loop
               Stealth::Logger.l(topic: 'catch_all', message: 'Stopping; we\'ve exceeded the number of defined catch_all states.')
-              release_lock!
               return false
             end
-          else
-            release_lock!
           end
         end
 

--- a/lib/stealth/controller/controller.rb
+++ b/lib/stealth/controller/controller.rb
@@ -61,41 +61,52 @@ module Stealth
     end
 
     def action(action: nil)
-      @action_name = action
-      @action_name ||= current_session.state_string
-
-      # Check if the user needs to be redirected
-      if current_session.flow.current_state.redirects_to.present?
-        Stealth::Logger.l(
-          topic: "redirect",
-          message: "From #{current_session.session} to #{current_session.flow.current_state.redirects_to.session}"
-        )
-        step_to(session: current_session.flow.current_state.redirects_to)
-        return
-      end
-
-      run_callbacks :action do
-        begin
-          flow_controller.send(@action_name)
-          unless flow_controller.progressed?
-            run_catch_all(reason: 'Did not send replies, update session, or step')
-          end
-        rescue StandardError => e
-          Stealth::Logger.l(
-            topic: "catch_all",
-            message: [e.message, e.backtrace.join("\n")].join("\n")
+      begin
+        # Grab a mutual exclusion lock on the session
+        lock_session!(
+          session_slug: Session.slugify(
+            flow: current_session.flow_string,
+            state: current_session.state_string
           )
+        )
 
-          # Store the reason so it can be accessed by the CatchAllsController
-          current_message.catch_all_reason = {
-            err: e.class,
-            err_msg: e.message
-          }
+        @action_name = action
+        @action_name ||= current_session.state_string
 
-          run_catch_all(reason: e.message)
-        ensure
-          release_lock!
+        # Check if the user needs to be redirected
+        if current_session.flow.current_state.redirects_to.present?
+          Stealth::Logger.l(
+            topic: "redirect",
+            message: "From #{current_session.session} to #{current_session.flow.current_state.redirects_to.session}"
+          )
+          step_to(session: current_session.flow.current_state.redirects_to)
+          return
         end
+
+        run_callbacks :action do
+          begin
+            flow_controller.send(@action_name)
+            unless flow_controller.progressed?
+              run_catch_all(reason: 'Did not send replies, update session, or step')
+            end
+          rescue StandardError => e
+            Stealth::Logger.l(
+              topic: "catch_all",
+              message: [e.message, e.backtrace.join("\n")].join("\n")
+            )
+
+            # Store the reason so it can be accessed by the CatchAllsController
+            current_message.catch_all_reason = {
+              err: e.class,
+              err_msg: e.message
+            }
+
+            run_catch_all(reason: e.message)
+          end
+        end
+      ensure
+        # Release mutual exclusion lock on the session
+        release_lock!
       end
     end
 
@@ -142,8 +153,6 @@ module Stealth
         flow: flow,
         state: state
       )
-
-      lock_session!(session_slug: Session.slugify(flow: flow, state: state))
 
       step(flow: flow, state: state)
     end

--- a/lib/stealth/controller/controller.rb
+++ b/lib/stealth/controller/controller.rb
@@ -93,6 +93,8 @@ module Stealth
           }
 
           run_catch_all(reason: e.message)
+        ensure
+          release_lock!
         end
       end
     end
@@ -158,7 +160,6 @@ module Stealth
         state: state
       )
       update_session(flow: flow, state: state)
-      release_lock!
     end
 
     def set_back_to(session: nil, flow: nil, state:)
@@ -193,7 +194,6 @@ module Stealth
 
     def do_nothing
       @progressed = :do_nothing
-      release_lock!
     end
 
     private

--- a/lib/stealth/controller/interrupt_detect.rb
+++ b/lib/stealth/controller/interrupt_detect.rb
@@ -84,10 +84,11 @@ module Stealth
             lock.create
           end
 
-          # Yields control to other threads to take action on this sessions
+          # Yields control to other threads to take action on this session
           # by releasing the lock.
           def release_lock!
-            # We cannot release the lock from within the interrupt handler
+            # We don't want to release the lock from within InterruptsController
+            # otherwise the InterruptsController can get interrupted.
             unless self.class.to_s == 'InterruptsController'
               current_lock&.release
             end

--- a/spec/controller/catch_all_spec.rb
+++ b/spec/controller/catch_all_spec.rb
@@ -110,23 +110,6 @@ describe "Stealth::Controller::CatchAll" do
       end
     end
 
-    describe "releasing locks" do
-      it "should release the session lock after the maximum number of catch_all levels have been reached" do
-        allow(controller).to receive(:fetch_error_level).and_return(4)
-        session = Stealth::Session.new(id: controller.current_session_id)
-        session.set_session(new_flow: 'vader', new_state: 'my_action')
-        expect(controller).to receive(:release_lock!)
-        controller.run_catch_all
-      end
-
-      it "should release the session lock if the bot does not have a CatchAll flow" do
-        # FlowMap.flow_spec[:catch_all] = nil
-        allow(FlowMap.flow_spec).to receive(:[]).with(:catch_all).and_return(nil)
-        expect(controller).to receive(:release_lock!)
-        controller.run_catch_all
-      end
-    end
-
     describe "catch_all_reason" do
       before(:each) do
         @session = Stealth::Session.new(id: controller.current_session_id)


### PR DESCRIPTION
This PR moves session locking and unlocking to a single method. This way it works more like mutex as it was designed to emulate. We also move the lock release to an `ensure` block to guarantee it is always run by Ruby and thereby fix the originally reported issue.

Fixes #194 