### PR TITLE
Fix ERB interpolation in database file while establishing connection

### DIFF
--- a/lib/stealth/base.rb
+++ b/lib/stealth/base.rb
@@ -126,8 +126,9 @@ module Stealth
       if ENV['DATABASE_URL'].present?
         ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
       else
+        database_config = File.read(File.join(Stealth.root, 'config', 'database.yml'))
         ActiveRecord::Base.establish_connection(
-          YAML::load_file("config/database.yml")[Stealth.env]
+          YAML.load(ERB.new(database_config).result)[Stealth.env]
         )
       end
     end


### PR DESCRIPTION
👋🏼
It looks like there is no way to use ENV variable in the `database.yml` file as it is not ERB parsed.
Currently we can either use DATABASE_URL env or plain value in the yaml (https://github.com/hellostealth/stealth/issues/266).

Parsing the file just like it's done for the `services.yml` would unblock this!