### PR TITLE
Add speech reply types to abstract class

### DIFF
--- a/lib/stealth/services/base_reply_handler.rb
+++ b/lib/stealth/services/base_reply_handler.rb
@@ -60,6 +60,14 @@ module Stealth
         reply_format_not_supported(format: 'delay')
       end
 
+      def speech
+        reply_format_not_supported(format: 'speech')
+      end
+
+      def ssml
+        reply_format_not_supported(format: 'ssml')
+      end
+
     end
   end
 end


### PR DESCRIPTION
Doesn't do anything yet, but in prep for voice/speech reply types we need this in the abstract reply class so the proper exceptions are thrown.