### PR TITLE
Improve speech and SSML replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [Replies] Dynamic delays are automatically sent before each reply. This can be disabled by setting `Stealth.config.auto_insert_delays` to `false`. If a delay is already included, the auto-delay is skipped.
 * [Controllers] `handle_message` now supports `Regexp` keys.
 * [Configuration] `database.yml` is now parsed with ERB in order to support environment variables. Thanks @malkovro.
+* [Replies] Speech and SSML replies now use `speech` and `ssml` as keys, respectively, instead of `text`
 
 ## Bug Fixes
 

--- a/lib/stealth/controller/replies.rb
+++ b/lib/stealth/controller/replies.rb
@@ -257,8 +257,12 @@ module Stealth
 
           def log_reply(reply)
             message = case reply.reply_type
-                      when 'text', 'speech'
+                      when 'text'
                         reply['text']
+                      when 'speech'
+                        reply['speech']
+                      when 'ssml'
+                        reply['ssml']
                       when 'delay'
                         '<typing indicator>'
                       else


### PR DESCRIPTION
Speech and SSML replies now use `speech` and `ssml` keys in reply files instead of `text`.

So for example:

Instead of:
```yaml
- reply_type: speech
  text: Hello World!
```
We instead do:
```yaml
- reply_type: speech
  speech: Hello World!
```