### PR TITLE
Log original error message when handling invalid sessions

### DIFF
--- a/lib/stealth/controller/replies.rb
+++ b/lib/stealth/controller/replies.rb
@@ -238,7 +238,8 @@ module Stealth
             else
               Stealth::Logger.l(
                 topic: :err,
-                message: "User #{current_session_id} unhandled exception due to invalid session_id."
+                message: "User #{current_session_id} unhandled exception due to an " \
+                         "invalid session_id. [#{msg}]"
               )
             end
 


### PR DESCRIPTION
Include in logs the original error that `Stealth::Errors::InvalidSessionID` raises, in order to help debugging these cases.