### PR TITLE
Add support for additional service errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 * [Controllers] `normalized_msg` and `homophone_translated_msg` are now memoized for performance.
 * [Errors] `Stealth::Errors::MessageNotRecognized` has been renamed to `Stealth::Errors::UnrecognizedMessage`
 * [Controllers] When `handle_message` or `get_match` raise a `Stealth::Errors::UnrecognizedMessage`, the user is first routed to a new `UnrecognizedMessagesController` to perform NLP. If that controller fails to match, the `catch_all` is run as normal.
-* [Errors] Client errors now call respective BotController actions: `handle_opt_out` and `handle_invalid_session_id`. Each client is responsible for raising `Stealth::Errors::UserOptOut` or `Stealth::Errors::InvalidSessionId` errors.
+* [Errors] Client errors now call respective BotController actions: `handle_opt_out`, `handle_invalid_session_id`, `handle_message_filtered`, `handle_unknown_error`. Each client is responsible for raising `Stealth::Errors::UserOptOut`, `Stealth::Errors::InvalidSessionId`, `Stealth::Errors::MessageFiltered`, `Stealth::Errors::UnknownError` errors, respectively.
 * [Controllers] `handle_message` and `get_match` now detect homophones for alpha ordinals (A-Z)
 * [Controllers] `handle_message` and `get_match` now ignore single and double quotes for alpha-ordinals
 * [CoreExt] Strings now have a `normalize` method for removing padding and quotes

--- a/lib/stealth/controller/replies.rb
+++ b/lib/stealth/controller/replies.rb
@@ -46,14 +46,14 @@ module Stealth
                 error_msg: msg
               )
               return
-            rescue MessageFiltered => e
+            rescue Stealth::Errors::MessageFiltered => e
               msg = "Message to user #{current_session_id} was filtered. [#{e.message}]"
               service_error_dispatcher(
                 handler_method: :handle_message_filtered,
                 error_msg: msg
               )
               return
-            rescue UnknownServiceError => e
+            rescue Stealth::Errors::UnknownServiceError => e
               msg = "User #{current_session_id} had an unknown error. [#{e.message}]"
               service_error_dispatcher(
                 handler_method: :handle_unknown_error,

--- a/lib/stealth/errors.rb
+++ b/lib/stealth/errors.rb
@@ -43,12 +43,20 @@ module Stealth
     class FlowDefinitionError < Errors
     end
 
+    # Service errors
     class InvalidSessionID < Errors
     end
 
     class UserOptOut < Errors
     end
 
+    class MessageFiltered < Errors
+    end
+
+    class UnknownServiceError < Errors
+    end
+
+    # Homophone errors
     class ReservedHomophoneUsed < Errors
     end
 

--- a/lib/stealth/generators/builder/bot/controllers/bot_controller.rb
+++ b/lib/stealth/generators/builder/bot/controllers/bot_controller.rb
@@ -40,15 +40,27 @@ private
   end
 
   # Automatically called when clients receive an opt-out error from
-  # the platform. You can write your own steps for handling.
+  # the platform. You may write your own steps for handling.
   def handle_opt_out
     do_nothing
   end
 
   # Automatically called when clients receive an invalid session_id error from
   # the platform. For example, attempting to text a landline.
-  # You can write your own steps for handling.
+  # You may write your own steps for handling.
   def handle_invalid_session_id
+    do_nothing
+  end
+
+  # Automatically called when a transmitted message is filtered/marked as spam.
+  # You may write your own steps for handling.
+  def handle_message_filtered
+    do_nothing
+  end
+
+  # Automatically called when an unknown error is returned by the platform.
+  # You may write your own steps for handling.
+  def handle_unknown_error
     do_nothing
   end
 


### PR DESCRIPTION
This PR adds support for two additional types of service errors:

1. `Stealth::Errors::MessageFiltered`
2. `Stealth::Errors::UnknownServiceError`

This brings the total to four:

```ruby
# Service errors
class InvalidSessionID < Errors
end

class UserOptOut < Errors
end

class MessageFiltered < Errors
end

class UnknownServiceError < Errors
end
```

The specifics of these errors are handled at the service level. See the respective service documentation for details.