### PR TITLE
Fix Logo for root path

### DIFF
--- a/lib/stealth/server.rb
+++ b/lib/stealth/server.rb
@@ -21,7 +21,7 @@ module Stealth
           <body>
             <center>
               <a href='https://hellostealth.org'>
-                <img src='http://assets.blackops.nyc/stealth/logo.svg' height='120' alt='Stealth Logo' aria-label='hellostealth.org' />
+                <img src='https://raw.githubusercontent.com/hellostealth/stealth/master/logo.svg' height='120' alt='Stealth Logo' aria-label='hellostealth.org' />
               </a>
             </center>
           </body>


### PR DESCRIPTION
Looks like this has broken. This points it from S3 to GitHub.