### PR TITLE
Handle bandwidth params structure

### DIFF
--- a/lib/stealth/server.rb
+++ b/lib/stealth/server.rb
@@ -35,7 +35,12 @@ module Stealth
       # JSON params need to be parsed and added to the params
       if request.env['CONTENT_TYPE']&.match(/application\/json/i)
         json_params = MultiJson.load(request.body.read)
-        params.merge!(json_params)
+
+        if bandwidth?
+          params[:bandwidth] = json_params.first
+        else
+          params.merge!(json_params)
+        end
       end
 
       dispatcher = Stealth::Dispatcher.new(
@@ -58,6 +63,10 @@ module Stealth
         request.env.select do |header, value|
           %w[HTTP_HOST].include?(header)
         end
+      end
+
+      def bandwidth?
+        params[:service] == "bandwidth"
       end
 
   end

--- a/lib/stealth/server.rb
+++ b/lib/stealth/server.rb
@@ -37,7 +37,7 @@ module Stealth
         json_params = MultiJson.load(request.body.read)
 
         if bandwidth?
-          params[:bandwidth] = json_params.first
+          params.merge!(json_params.first)
         else
           params.merge!(json_params)
         end


### PR DESCRIPTION
[Bandwidth service](https://dev.bandwidth.com/docs/messaging/webhooks/) sends message callbacks to the webhook url as as a list/array `[ {message metadata} ]`, where Stealth expects a hash `{ }`.