### PR TITLE
Sidekiq config updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport (~> 6.0)
       multi_json (~> 1.12)
       puma (>= 4.2, < 6.0)
-      sidekiq (~> 6.0)
+      sidekiq (> 6.5)
       sinatra (~> 2.0)
       thor (~> 1.0)
 
@@ -55,7 +55,7 @@ GEM
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby2_keywords (0.0.5)
-    sidekiq (6.5.6)
+    sidekiq (6.5.7)
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)

--- a/lib/stealth/base.rb
+++ b/lib/stealth/base.rb
@@ -123,7 +123,7 @@ module Stealth
 
     load_bot!
 
-    Sidekiq.options[:reloader] = Stealth.bot_reloader
+    Sidekiq[:reloader] = Stealth.bot_reloader
 
     if defined?(ActiveRecord)
       if ENV['DATABASE_URL'].present?

--- a/stealth.gemspec
+++ b/stealth.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'puma', '>= 4.2', '< 6.0'
   s.add_dependency 'thor', '~> 1.0'
   s.add_dependency 'multi_json', '~> 1.12'
-  s.add_dependency 'sidekiq', '~> 6.0'
+  s.add_dependency 'sidekiq', '> 6.5'
   s.add_dependency 'activesupport', '~> 6.0'
 
   s.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
Fix [Sidekiq warning](https://github.com/mperham/sidekiq/blob/7037533e8f39cc1d3c1e305140da7667c6efe38f/lib/sidekiq.rb#L96) for versions > 6.5 

```
WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`
```

