### PR TITLE
Check if Bandwidth passes an array as params

### DIFF
--- a/lib/stealth/server.rb
+++ b/lib/stealth/server.rb
@@ -39,6 +39,8 @@ module Stealth
         if bandwidth?
           if json_params.is_a?(Array)
             params.merge!(json_params.first)
+          else
+            # Ignoring inbound calls
           end
         else
           params.merge!(json_params)

--- a/lib/stealth/server.rb
+++ b/lib/stealth/server.rb
@@ -40,7 +40,7 @@ module Stealth
           if json_params.is_a?(Array)
             params.merge!(json_params.first)
           else
-            # Ignoring inbound calls
+            return [200, 'Ok']
           end
         else
           params.merge!(json_params)

--- a/lib/stealth/server.rb
+++ b/lib/stealth/server.rb
@@ -37,7 +37,9 @@ module Stealth
         json_params = MultiJson.load(request.body.read)
 
         if bandwidth?
-          params.merge!(json_params.first)
+          if json_params.is_a?(Array)
+            params.merge!(json_params.first)
+          end
         else
           params.merge!(json_params)
         end


### PR DESCRIPTION
Ignore Bandwidth.com voice service webhook calls that pass hashes as parameters.
