### PR TITLE
Add safe yaml file load

### DIFF
--- a/lib/stealth/base.rb
+++ b/lib/stealth/base.rb
@@ -75,7 +75,13 @@ module Stealth
     if ENV['DATABASE_URL'].present? && defined?(ActiveRecord)
       ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
     else
-      ActiveRecord::Base.establish_connection(YAML::load_file("config/database.yml")[Stealth.env])
+      database_config = File.read(File.join(Stealth.root, 'config', 'database.yml'))
+      yaml_file = begin
+                    YAML.load(database_config, aliases: true)
+                  rescue ArgumentError
+                    YAML.load(database_config)
+                  end
+      ActiveRecord::Base.establish_connection(yaml_file[Stealth.env])
     end
   end
 


### PR DESCRIPTION
To prevent errors with rubies > 3.1


If you have ruby > 3.1 e.g. ruby-3.1.2, then execute `gem install stealth`, `stealth new <bot>` and `bundle exec puma -C config/puma.rb` you'll get something like this: 

Puma starting in single mode...
* Version 3.12.6 (ruby 3.1.2-p20), codename: Llamas in Pajamas
* Min threads: 5, max threads: 5
* Environment: development
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
! Unable to load application: Psych::BadAlias: Unknown alias: default
/Users/ilyaklapatok/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:430:in `visit_Psych_Nodes_Alias': Unknown alias: default (Psych::BadAlias)

You can read about the issue here: https://bugs.ruby-lang.org/issues/17866
