### PR TITLE
Remove ubuntu 18 and add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-latest]
-        ruby: [ 2.7, 3.0, 3.1, truffleruby-head ]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest]
+        ruby: [ 2.7, 3.0, 3.1, 3.2, truffleruby-head ]
         exclude:
           - os: ubuntu-22.04
             ruby: 2.7


### PR DESCRIPTION
Ubuntu 18 is deprecated.