### PR TITLE
Remove signature from text messages

### DIFF
--- a/lib/stealth/core_ext/string.rb
+++ b/lib/stealth/core_ext/string.rb
@@ -15,4 +15,8 @@ class String
     self.gsub(EXCLUDED_CHARS_RE, '')
   end
 
+  def remove_signature
+    self.include?("\n") ? self.split("\n")[0] : self
+  end
+
 end


### PR DESCRIPTION
*This is a feature branch of the fix/bandwidth branch*

The PR adds a 'slice' argument to the `handle_message` and `get_match` methods with a default value of `true` to automatically slice any text message content after a line break (i.e. assuming that the presence of a line break is for an SMS/text message signature).

To disable it, we need to explicitly pass the argument with a `false` value to the methods

```
handle_message(
      false,
      :yes => proc {
        puts 'Yes'
      },
      :no => proc {
        puts 'No'
      }
)

messages = get_match(
      [
        'Yes',
        'No',
        'Maybe'
      ], slice: false
    )
```