### PR TITLE
Added optional sanitized param to say method

### DIFF
--- a/app/controllers/stealth/controller/replies.rb
+++ b/app/controllers/stealth/controller/replies.rb
@@ -76,8 +76,8 @@ module Stealth
           Stealth.trigger_reply(flow, state, current_message)
         end
 
-        def say(reply, thread_id: nil)
-          reply_instance = Stealth::Reply.new(unstructured_reply: reply)
+        def say(reply, thread_id: nil, sanitized: true)
+          reply_instance = Stealth::Reply.new(unstructured_reply: reply, sanitized: sanitized)
 
           handler = reply_handler.new(
             recipient_id: current_message.sender_id,

--- a/lib/stealth/reply.rb
+++ b/lib/stealth/reply.rb
@@ -3,11 +3,12 @@
 
 module Stealth
   class Reply
-    attr_reader :reply_type, :reply
+    attr_reader :reply_type, :reply, :sanitized
 
-    def initialize(unstructured_reply:)
+    def initialize(unstructured_reply:, sanitized: true)
       @reply = sanitize_reply(unstructured_reply)
       @reply_type = determine_reply_type
+      @sanitized = sanitized
     end
 
     def [](key)
@@ -50,7 +51,11 @@ module Stealth
     end
 
     def sanitize(value)
-      ActionView::Base.full_sanitizer.sanitize(value)
+      if sanitized
+        ActionView::Base.full_sanitizer.sanitize(value)
+      else
+        value
+      end
     end
   end
 end


### PR DESCRIPTION
Now you can use `say` method as so:
`say(reply, thread_id: , sanitized: false)`
This prevents removing LLM md formatting 