### PR TITLE
Use LLM for handling unrecognized messages

### DIFF
--- a/app/controllers/stealth/controller.rb
+++ b/app/controllers/stealth/controller.rb
@@ -7,6 +7,7 @@ module Stealth
     include Stealth::Controller::InterruptDetect
     include Stealth::Controller::Messages
     include Stealth::Controller::Nlp
+    include Stealth::Controller::Llm
     include Stealth::Controller::Replies
     include Stealth::Controller::CatchAll
     include Stealth::Controller::UnrecognizedMessage
@@ -172,14 +173,6 @@ module Stealth
         back_to_session.set_session(new_flow: flow, new_state: state)
       end
 
-      # def step(flow:, state:, pos: nil)
-      #   update_session(flow: flow, state: state)
-      #   Stealth.trigger_flow(flow, state, @current_message)
-
-      #   @progressed = :stepped
-      #   @pos = pos
-      # end
-
       def step(flow:, state:, pos: nil)
         update_session(flow: flow, state: state)
 
@@ -201,6 +194,8 @@ module Stealth
         rescue StandardError => e
           if e.is_a?(Stealth::Errors::UnrecognizedMessage)
             run_unrecognized_message(err: e)
+          elsif e.is_a?(Stealth::Errors::FlowTriggered)
+            redirect_to_llm_intent
           else
             run_catch_all(err: e)
           end

--- a/app/controllers/stealth/controller/llm.rb
+++ b/app/controllers/stealth/controller/llm.rb
@@ -1,0 +1,60 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+module Stealth
+  class Controller
+    module Llm
+
+      extend ActiveSupport::Concern
+
+      included do
+        def perform_llm!
+          Stealth::Logger.l(
+            topic: :llm,
+            message: "User #{current_session_id} -> Querying LLM for intent detection."
+          )
+
+          @llm_result ||= begin
+            llm_response = get_intent(current_message.message)
+            current_message.llm_result = llm_response
+
+            if llm_response.blank?
+              Stealth::Logger.l(
+                topic: :llm,
+                message: "User #{current_session_id} -> No intent detected."
+              )
+              return nil
+            end
+
+            intent_name = llm_response[:intent].to_sym
+            Stealth::Logger.l(
+              topic: :llm,
+              message: "User #{current_session_id} -> LLM resulting intent: #{intent_name}."
+            )
+
+            llm_response
+          rescue StandardError => e
+            Stealth::Logger.l(
+              topic: :llm,
+              message: "User #{current_session_id} -> LLM API Error: #{e.message}"
+            )
+            nil
+          end
+        end
+
+        def redirect_to_llm_intent
+          intent = current_message.llm_result&.dig(:intent)
+
+          unless intent.present?
+            error = Stealth::Errors::UnrecognizedMessage.new("Missing intent in LLM result")
+            return run_unrecognized_message(err: error)
+          end
+
+          step_to(flow: intent.to_sym)
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/stealth/errors.rb
+++ b/lib/stealth/errors.rb
@@ -43,6 +43,9 @@ module Stealth
     class FlowDefinitionError < Errors
     end
 
+    class FlowTriggered < Errors
+    end
+
     # Service errors
     class InvalidSessionID < Errors
     end

--- a/lib/stealth/logger.rb
+++ b/lib/stealth/logger.rb
@@ -44,7 +44,7 @@ module Stealth
                 :magenta
               when :alexa, :voice, :twilio_voice, :unrecognized_message
                 :light_cyan
-              when :nlp
+              when :nlp, :llm
                 :cyan
               when :catch_all, :err
                 :red

--- a/lib/stealth/service_event.rb
+++ b/lib/stealth/service_event.rb
@@ -16,6 +16,7 @@ module Stealth
                   :payload,
                   :referral,
                   :nlp_result,
+                  :llm_result,
                   :catch_all_reason,
                   :confidence
 


### PR DESCRIPTION
Stealth now returns LLM-detected intents instead of raising an unrecognized message error