### PR TITLE
Add support for callback helpers

### DIFF
--- a/app/controllers/stealth/controller.rb
+++ b/app/controllers/stealth/controller.rb
@@ -225,7 +225,7 @@ module Stealth
             flow_states = flow_manager.instance_variable_get(:@flows)[flow.to_sym]
 
             if flow_states.present?
-              state = flow_states.keys.first.to_s
+              state = flow_states[:states].keys.first.to_s
             else
               raise ArgumentError, "No states defined for flow: #{flow}"
             end

--- a/lib/stealth/flow_manager.rb
+++ b/lib/stealth/flow_manager.rb
@@ -6,13 +6,21 @@ module Stealth
 
     def register_flow(flow_name, &block)
       @current_flow = flow_name.to_sym
+
+      @flows[@current_flow] = {
+        states: {},
+        callbacks: Hash.new { |h, k| h[k] = [] }
+      }
+
       instance_eval(&block)
       @current_flow = nil
     end
 
     def state(state_name, **options, &block)
-      @flows[@current_flow] ||= {}
-      @flows[@current_flow][state_name.to_sym] = { block: block, options: options }
+      @flows[@current_flow][:states][state_name.to_sym] = {
+        block: block,
+        options: options
+      }
     end
 
     def current_state(session)
@@ -21,48 +29,66 @@ module Stealth
       flow_states = @flows[session.flow_string.to_sym]
       return nil unless flow_states
 
-      flow_states[session.state]
+      flow_states[:states][session.state.to_sym]
     end
 
     def trigger_flow(flow_name, state_name, service_event)
       flow_name = flow_name.to_sym
       state_name = state_name.to_sym
 
-      if @flows[flow_name] && @flows[flow_name][state_name]
-        state_info = @flows[flow_name][state_name]
-        block = state_info[:block]
-        options = state_info[:options]
+      flow = @flows[flow_name]
+      return unless flow
 
-        # Always use DslEventContext if defined in the Rails app
-        context_class = defined?(Stealth::DslEventContext) ? Stealth::DslEventContext : Stealth::Controller
-        context = context_class.new(service_event: service_event)
+      state_info = flow[:states][state_name]
+      return unless state_info
 
-        block_context = Class.new do
-          def initialize(context, options)
-            @context = context
-            @options = options
+      block = state_info[:block]
+      options = state_info[:options]
+
+      context_class = defined?(Stealth::DslEventContext) ? Stealth::DslEventContext : Stealth::Controller
+      context = context_class.new(service_event: service_event)
+
+      callbacks = flow[:callbacks] || {}
+
+      callbacks[:before_state]&.each do |callback|
+        context.public_send(callback) if context.respond_to?(callback)
+      end
+
+      block_context = Class.new do
+        def initialize(context, options)
+          @context = context
+          @options = options
+        end
+
+        def method_missing(method_name, *args, **kwargs, &block)
+          if @context.respond_to?(method_name)
+            @context.public_send(method_name, *args, **kwargs, &block)
+          else
+            super
           end
+        end
 
-          def method_missing(method_name, *args, **kwargs, &block)
-            if @context.respond_to?(method_name)
-              @context.public_send(method_name, *args, **kwargs, &block)
-            else
-              super
-            end
-          end
+        def respond_to_missing?(method_name, include_private = false)
+          @context.respond_to?(method_name) || super
+        end
 
-          def respond_to_missing?(method_name, include_private = false)
-            @context.respond_to?(method_name) || super
-          end
+        def state_options
+          @options
+        end
+      end.new(context, options)
 
-          def state_options
-            @options
-          end
-        end.new(context, options)
-
-        block_context.instance_exec(service_event, &block)
+      around_callbacks = callbacks[:around_state] || []
+      if around_callbacks.any?
+        chain = around_callbacks.reverse.inject(-> { block_context.instance_exec(service_event, &block) }) do |next_proc, callback|
+          -> { context.public_send(callback) { next_proc.call } }
+        end
+        chain.call
       else
-        Stealth::Logger.l(topic: 'user', message: "No flow found for #{flow_name} with state #{state_name}")
+        block_context.instance_exec(service_event, &block)
+      end
+
+      callbacks[:after_state]&.each do |callback|
+        context.public_send(callback) if context.respond_to?(callback)
       end
     end
 
@@ -71,7 +97,7 @@ module Stealth
     end
 
     def state_exists?(flow_name, state_name)
-      @flows.dig(flow_name.to_sym, state_name.to_sym).present?
+      @flows.dig(flow_name.to_sym, :states, state_name.to_sym).present?
     end
 
     def self.instance
@@ -85,5 +111,19 @@ module Stealth
     def self.trigger_flow(flow_name, state_name, service_event)
       instance.trigger_flow(flow_name, state_name, service_event)
     end
+
+    # Callbacks
+    def before_state(method_name)
+      @flows[@current_flow][:callbacks][:before_state] << method_name
+    end
+
+    def after_state(method_name)
+      @flows[@current_flow][:callbacks][:after_state] << method_name
+    end
+
+    def around_state(method_name)
+      @flows[@current_flow][:callbacks][:around_state] << method_name
+    end
+
   end
 end

--- a/lib/stealth/session.rb
+++ b/lib/stealth/session.rb
@@ -61,7 +61,7 @@ module Stealth
       return nil if flow.blank? || state_string.blank?
 
       state_symbol = state_string.to_sym
-      return state_symbol if flow.key?(state_symbol)
+      return state_symbol if flow[:states].key?(state_symbol)
 
       nil
     end


### PR DESCRIPTION
This PR introduces support for `before_state`, `after_state`, and `around_state` callbacks within the `FlowManager`.

These callbacks can now be defined in the flow DSL and are automatically invoked during state transitions:

- `before_state` runs before the state block,
- `after_state` runs after the state block, and
- `around_state` wraps the state block, enabling advanced behaviors like pre- and post-processing.

Additionally, the flow structure has been updated to support nested states, with callbacks as a top-level key.
The structure now looks like this:

```
@flows = {
  hello: {
    states: {
      say_hello: { block: ..., options: ... },
      ...
    },
    callbacks: { before_state: [ ], around_state: [ ], after_state: [ ] }
  }
}
```