### PR TITLE
Enable Hot Reloading for Flows, States, and Replies in Stealth

### DIFF
--- a/lib/stealth/flow_manager.rb
+++ b/lib/stealth/flow_manager.rb
@@ -36,6 +36,9 @@ module Stealth
       flow_name = flow_name.to_sym
       state_name = state_name.to_sym
 
+      should_reload = Stealth.env.development? || !@flows.key?(flow_name)
+      load_flow_file(flow_name) if should_reload # force reload on every request in dev
+
       flow = @flows[flow_name]
       return unless flow
 
@@ -110,6 +113,16 @@ module Stealth
 
     def self.trigger_flow(flow_name, state_name, service_event)
       instance.trigger_flow(flow_name, state_name, service_event)
+    end
+
+    def load_flow_file(flow_name)
+      flow_file_path = Rails.root.join("stealth/flows", "#{flow_name}_flow.rb")
+
+      if File.exist?(flow_file_path)
+        load flow_file_path
+      else
+        Stealth::Logger.l(topic: 'flow', message: "Flow file not found: #{flow_file_path}")
+      end
     end
 
     # Callbacks

--- a/lib/stealth/reply_manager.rb
+++ b/lib/stealth/reply_manager.rb
@@ -12,10 +12,10 @@ module Stealth
     def trigger_reply(flow_name, state_name, service_event)
       flow_state_key = "#{flow_name}/#{state_name}".to_sym
 
-      # Check if reply is already registered
-      unless @replies.key?(flow_state_key)
-        # Load reply file based on flow and state if not registered
-        load_reply_file(flow_name, state_name)
+      if Stealth.env.development?
+        load_reply_file(flow_name, state_name)  # force reload on every request in dev
+      else
+        load_reply_file(flow_name, state_name) unless @replies.key?(flow_state_key)
       end
 
       if @replies.key?(flow_state_key)


### PR DESCRIPTION
This PR enhances the Stealth engine by enabling hot reloading of flow definitions, states, and reply files during development, allowing developers to update logic without restarting the Rails server.

**Details:**

**Flows and States:**
- In `FlowManager#trigger_flow`, flow files are reloaded on every request in development, or when a flow is not yet loaded.
- If a state is missing from the loaded flow, the flow file is reloaded once more in development to pick up recent changes.
- This allows seamless renaming or editing of flows and states with instant effect.

**Replies:**
- In `ReplyManager#trigger_reply`, reply files are always reloaded on every request in development.
- In other environments, reply files are loaded only if not already registered (cached).
- This removes the need to restart the server to see changes in replies.

**Notes:**
- Flow files are expected under `stealth/flows/`, and reply files under `stealth/replies/`.
