### PR TITLE
update job queues

### DIFF
--- a/lib/stealth/services/jobs/handle_event_job.rb
+++ b/lib/stealth/services/jobs/handle_event_job.rb
@@ -5,7 +5,7 @@ module Stealth
   module Services
 
     class HandleEventJob < Stealth::Jobs
-      sidekiq_options queue: :realtime, retry: false
+      sidekiq_options queue: :realtime_standard_2x, retry: false
 
       def perform(service, params, headers)
         dispatcher = Stealth::Dispatcher.new(

--- a/lib/stealth/services/jobs/handle_event_job.rb
+++ b/lib/stealth/services/jobs/handle_event_job.rb
@@ -5,7 +5,7 @@ module Stealth
   module Services
 
     class HandleEventJob < Stealth::Jobs
-      sidekiq_options queue: :stealth3_webhooks, retry: false
+      sidekiq_options queue: :realtime, retry: false
 
       def perform(service, params, headers)
         dispatcher = Stealth::Dispatcher.new(

--- a/lib/stealth/services/jobs/scheduled_reply_job.rb
+++ b/lib/stealth/services/jobs/scheduled_reply_job.rb
@@ -5,7 +5,7 @@ module Stealth
   module Services
 
     class ScheduledReplyJob < Stealth::Jobs
-      sidekiq_options queue: :realtime, retry: false
+      sidekiq_options queue: :realtime_standard_2x, retry: false
 
       def perform(service, user_id, flow, state, target_id=nil)
         service_event = ServiceEvent.new(service: service)

--- a/lib/stealth/services/jobs/scheduled_reply_job.rb
+++ b/lib/stealth/services/jobs/scheduled_reply_job.rb
@@ -5,7 +5,7 @@ module Stealth
   module Services
 
     class ScheduledReplyJob < Stealth::Jobs
-      sidekiq_options queue: :stealth3_replies, retry: false
+      sidekiq_options queue: :realtime, retry: false
 
       def perform(service, user_id, flow, state, target_id=nil)
         service_event = ServiceEvent.new(service: service)


### PR DESCRIPTION
This updates the job queue name for HandleEventJob and ScheduledReplyJob as part of refactoring our background jobs.

This is required by https://github.com/hiremav/mav/pull/2763. See that PR for context.